### PR TITLE
Update __init__ method of meta.py

### DIFF
--- a/nel/features/meta.py
+++ b/nel/features/meta.py
@@ -11,7 +11,12 @@ log = logging.getLogger()
 class ClassifierFeature(Feature):
     """ Computes a feature score based on the output of a classifier over a set of features. """
     def __init__(self, classifier):
-        self.classifier = classifier
+        if isinstance(classifier,(str,unicode)):
+           self.classifier = Classifier.load(classifier) 
+        elif isinstance(classifier,Classifier):
+            self.classifier = classifier
+        else:
+            raise Exception("Unknown classifier %s."%classifier)
 
     def compute_doc_state(self, doc):
         doc = self.classifier.mapper(doc) 
@@ -41,3 +46,4 @@ class ClassifierProbability(ClassifierFeature):
 
     def predict(self, fv):
         return self.classifier.model.predict_proba(fv)[0][1]
+    

--- a/nel/features/meta.py
+++ b/nel/features/meta.py
@@ -10,13 +10,11 @@ log = logging.getLogger()
 
 class ClassifierFeature(Feature):
     """ Computes a feature score based on the output of a classifier over a set of features. """
-    def __init__(self, classifier):
-        if isinstance(classifier,(str,unicode)):
-           self.classifier = Classifier.load(classifier) 
-        elif isinstance(classifier,Classifier):
-            self.classifier = classifier
-        else:
-            raise Exception("Unknown classifier %s."%classifier)
+    def __init__(self, classifier=None, classifier_model_tag=None):
+        if (classifier_model_tag is None) == (classifier is None):
+            raise Exception('You must provide a classifier_model_tag or classifier instance, but not both.')
+        self.classifier = classifier or Classifier.load(classifier_model_tag) 
+
 
     def compute_doc_state(self, doc):
         doc = self.classifier.mapper(doc) 


### PR DESCRIPTION
the `ClassifierFeature class` accept a `classifier` positional parameter, it should be a `Classifier` instance. But when we  use `process.pipeline.Pipeline.load()` to load our system's config file(e.g,config.json), it will create a `ClassifierFeature` instance with 'ranker' as `classifier` parameter which is not a `Classifier` instance and will  raise a error when scoring for a doc. I modify the code in the `__init__`  as follow:
```python 
        if isinstance(classifier,(str,unicode)):
           self.classifier = Classifier.load(classifier) 
        elif isinstance(classifier,Classifier):
            self.classifier = classifier
        else:
            raise Exception("Unknown classifier %s."%classifier)
```
After that, the following code can run through:
 ```python
         linker = Pipeline('config.json')
         doc = linker(doc)
```
I hope it is useful.